### PR TITLE
add contribution pie chart in Github board

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "element-ui": "^2.5.4",
     "vue": "^2.5.22",
+    "vue-google-charts": "^0.3.2",
     "vue-router": "^3.0.1",
     "vuelidate": "^0.7.4",
     "vuetify": "^1.5.0",

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -1,17 +1,12 @@
 <template>
     <v-card height="50%">
         <v-container width="100%">
-            <v-container>
-                <v-layout justify-center>
-                    <GChart
-                            type="PieChart"
-                            :data="data[0]"
-                            :options="{
-                                title:'contribution by commits',
-                                titleTextStyle: {
-                                    fontSize: 16
-                                },
-
+            <h4>{{title}}</h4>
+            <v-layout justify-center>
+                <GChart
+                        type="PieChart"
+                        :data="data"
+                        :options="{
                                 legend: { position: 'left', maxLines:4},
                                 width: 700,
                                 height: 450,
@@ -24,33 +19,8 @@
                                     height:450
                                 }
                              }"
-                    />
-                    <GChart
-                            type="PieChart"
-                            :data="data[1]"
-                            :options="{
-                                title:'contribution by LOC',
-                                titleTextStyle: {
-                                    fontSize: 16
-                                },
-                                legend:'left',
-                                width: 700,
-                                height: 450,
-                                chartArea:{
-                                    left:100,
-                                    top:40,
-                                    right:10,
-                                    bottom:40,
-                                    width:450,
-                                    height:450
-                                }
-                             }"
-                    />
-                </v-layout>
-                <v-container>
-
-                </v-container>
-            </v-container>
+                />
+            </v-layout>
         </v-container>
     </v-card>
 
@@ -63,6 +33,6 @@
         components: {
             GChart
         },
-        props: ["data"]
+        props: ["data", "title"]
     }
 </script>

--- a/src/components/PieChart.vue
+++ b/src/components/PieChart.vue
@@ -1,0 +1,68 @@
+<template>
+    <v-card height="50%">
+        <v-container width="100%">
+            <v-container>
+                <v-layout justify-center>
+                    <GChart
+                            type="PieChart"
+                            :data="data[0]"
+                            :options="{
+                                title:'contribution by commits',
+                                titleTextStyle: {
+                                    fontSize: 16
+                                },
+
+                                legend: { position: 'left', maxLines:4},
+                                width: 700,
+                                height: 450,
+                                chartArea:{
+                                    left:10,
+                                    top:40,
+                                    right:100,
+                                    bottom:40,
+                                    width:800,
+                                    height:450
+                                }
+                             }"
+                    />
+                    <GChart
+                            type="PieChart"
+                            :data="data[1]"
+                            :options="{
+                                title:'contribution by LOC',
+                                titleTextStyle: {
+                                    fontSize: 16
+                                },
+                                legend:'left',
+                                width: 700,
+                                height: 450,
+                                chartArea:{
+                                    left:100,
+                                    top:40,
+                                    right:10,
+                                    bottom:40,
+                                    width:450,
+                                    height:450
+                                }
+                             }"
+                    />
+                </v-layout>
+                <v-container>
+
+                </v-container>
+            </v-container>
+        </v-container>
+    </v-card>
+
+</template>
+
+<script>
+    import { GChart } from 'vue-google-charts'
+    export default {
+        name: "PieChart",
+        components: {
+            GChart
+        },
+        props: ["data"]
+    }
+</script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -97,3 +97,23 @@ export const GRADIENT = [
     ['#00c6ff', '#F0F', '#FF0'],
     ['#f72047', '#ffd200', '#1feaea']
 ];
+
+export const PIEDATA = [
+    [
+        ['Contribution', 'commits'],
+        ['member 1', 2],
+        ['member 2', 3],
+        ['member 3', 4],
+        ['member 4', 5],
+        ['member 5', 3]
+    ],
+    [
+        ['Contribution', 'commits'],
+        ['member 1', 30],
+        ['member 2', 50],
+        ['member 3', 40],
+        ['member 4', 30],
+        ['member 5', 10]
+    ]
+
+];

--- a/src/tabs/GithubContribution.vue
+++ b/src/tabs/GithubContribution.vue
@@ -1,0 +1,24 @@
+<template>
+    <v-card height="50%">
+        <v-container width="100%">
+            <v-container>
+                <v-layout justify-center>
+                    <pie-chart :data="data[0]" title="contribution by pull request"></pie-chart>
+                    <pie-chart :data="data[1]" title="contribution by commit"></pie-chart>
+                </v-layout>
+            </v-container>
+        </v-container>
+    </v-card>
+
+</template>
+
+<script>
+    import PieChart from "../components/PieChart"
+    export default {
+        name: "GithubContribution",
+        components: {
+            PieChart
+        },
+        props: ["data"]
+    }
+</script>

--- a/src/views/GitHub.vue
+++ b/src/views/GitHub.vue
@@ -17,6 +17,8 @@
     import {HEADERS1} from "../constants";
     import {MEMBERS} from "../constants";
     import {COMPLEXITY} from "../constants";
+    import PieChart from "@/components/PieChart";
+    import {PIEDATA} from "../constants";
 
     export default {
         name: "Github",
@@ -29,6 +31,8 @@
                     'Code Complexity': {data: COMPLEXITY, component: CircleChart, title: 'Contributions', headers: null},
                     //'Pull Requests': {data: GRADIENT, component: SparkLine, title: 'Burn Down Chart', headers: null}
                     //'Comments': {data: PROCESSES, component: BarChart, title: 'User Stories', headers: null}
+                    'Contribution': {data: PIEDATA, component: PieChart,
+                        title: '["contribution by commits", "contribution by LOC"]'}
                 }
             }
         }

--- a/src/views/GitHub.vue
+++ b/src/views/GitHub.vue
@@ -9,16 +9,17 @@
     import DataTable from "@/components/DataTable";
     //import {HEADERS} from "@/constants";
     //import {USER_STORIES} from "@/constants";
-    import {PROCESSES} from "@/constants";
-    import {GRADIENT} from "@/constants";
+    //import {PROCESSES} from "@/constants";
+    //import {GRADIENT} from "@/constants";
     import CircleChart from "@/components/CircleChart";
-    import SparkLine from "@/components/SparkLine";
-    import BarChart from "@/components/BarChart";
+    //import SparkLine from "@/components/SparkLine";
+    //import BarChart from "@/components/BarChart";
+    import GithubContribution from "../tabs/GithubContribution"
     import {HEADERS1} from "../constants";
     import {MEMBERS} from "../constants";
     import {COMPLEXITY} from "../constants";
-    import PieChart from "@/components/PieChart";
     import {PIEDATA} from "../constants";
+
 
     export default {
         name: "Github",
@@ -31,8 +32,7 @@
                     'Code Complexity': {data: COMPLEXITY, component: CircleChart, title: 'Contributions', headers: null},
                     //'Pull Requests': {data: GRADIENT, component: SparkLine, title: 'Burn Down Chart', headers: null}
                     //'Comments': {data: PROCESSES, component: BarChart, title: 'User Stories', headers: null}
-                    'Contribution': {data: PIEDATA, component: PieChart,
-                        title: '["contribution by commits", "contribution by LOC"]'}
+                    'Contribution': {data: PIEDATA, component: GithubContribution, }
                 }
             }
         }


### PR DESCRIPTION
tow pie chart: one for contribution by commits, the other for contibution by lines of codes
![image](https://user-images.githubusercontent.com/35699883/54147754-0cf36300-43f0-11e9-9fb2-9e4e9f9c0584.png)
