### PR TITLE
refactor the contribution chart for github ----US37 Task38

### DIFF
--- a/src/components/ComboChart.vue
+++ b/src/components/ComboChart.vue
@@ -1,0 +1,39 @@
+<template>
+    <v-card>
+        <v-container width="100%">
+            <h3>{{title}} timeline</h3>
+            <v-layout justify-center>
+                <GChart
+                        type="ComboChart"
+                        :data="data"
+                        :options="{
+                                vAxis: {
+                                    textPosition: 'in',
+                                    title: 'count'
+                                },
+                                seriesType: 'bars',
+                                series: {3: {type: 'line'}},
+                                width: 700,
+                                height: 450,
+                                chartArea:{
+                                    top: 20,
+                                    bottom: 50,
+                                    left: 120,
+                                    right: 120,
+                                },
+                             }"
+                />
+            </v-layout>
+        </v-container>
+    </v-card>
+</template>
+<script>
+    import { GChart } from 'vue-google-charts'
+    export default {
+        name: "ComboChart",
+        components: {
+            GChart
+        },
+        props: ["data", "title"]
+    }
+</script>

--- a/src/components/TableChart.vue
+++ b/src/components/TableChart.vue
@@ -1,0 +1,54 @@
+<template>
+    <v-container :width="700">
+        <v-card>
+            <v-card-title>
+                Nutrition
+                <v-spacer></v-spacer>
+                <v-text-field
+                        append-icon="search"
+                        label="Search"
+                        single-line
+                        hide-details
+                        v-model="search"
+                ></v-text-field>
+            </v-card-title>
+            <v-data-table
+                    :headers="headers"
+                    :items="data"
+                    :search="search"
+                    class="elevation-1"
+            >
+                <template slot="items" slot-scope="props">
+                    <td class="text-xs-center">{{ props.item.name }}</td>
+                    <td class="text-xs-left">{{ props.item.codeQuality }}</td>
+                </template>
+                <v-alert slot="no-results" :value="true" color="error" icon="warning">
+                    Your search for "{{ search }}" found no results.
+                </v-alert>
+            </v-data-table>
+        </v-card>
+
+    </v-container>
+
+</template>
+
+<script>
+    export default {
+        name: "TableChart",
+        props: ["data", "headers", "title"],
+        data() {
+            return {
+                search: ''
+            }
+        },
+    }
+</script>
+
+<style scoped>
+    table.v-table thead {
+        font-size: 24px;
+    }
+    table.v-table tbody tr td {
+        font-size: 14px;
+    }
+</style>

--- a/src/components/TableChart.vue
+++ b/src/components/TableChart.vue
@@ -2,7 +2,7 @@
     <v-container :width="700">
         <v-card>
             <v-card-title>
-                Nutrition
+                <div class="title font-weight-regular">{{title}}</div>
                 <v-spacer></v-spacer>
                 <v-text-field
                         append-icon="search"

--- a/src/components/TableChart.vue
+++ b/src/components/TableChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-container :width="700">
+    <v-container>
         <v-card>
             <v-card-title>
                 <div class="title font-weight-regular">{{title}}</div>
@@ -20,7 +20,9 @@
             >
                 <template slot="items" slot-scope="props">
                     <td class="text-xs-center">{{ props.item.name }}</td>
-                    <td class="text-xs-left">{{ props.item.codeQuality }}</td>
+                    <td class="text-xs-left"
+                        :style="{ color: props.item.codeQuality>=60?props.item.codeQuality>=80?'green':'orange':'red' }"
+                    >{{ props.item.codeQuality }}</td>
                 </template>
                 <v-alert slot="no-results" :value="true" color="error" icon="warning">
                     Your search for "{{ search }}" found no results.

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,36 +44,11 @@ export const HEADERS1 = [
 ];
 
 export const MEMBERS = [
-    {
-        name: 'Abigail',
-        property1: 10,
-        property2: 5,
-        property3: 8
-    },
-    {
-        name: 'James',
-        property1: 10,
-        property2: 6,
-        property3: 8
-    },
-    {
-        name: 'John',
-        property1: 10,
-        property2: 6,
-        property3: 8
-    },
-    {
-        name: 'Anna',
-        property1: 10,
-        property2: 5,
-        property3: 8
-    },
-    {
-        name: 'Lucy',
-        property1: 10,
-        property2: 5,
-        property3: 8
-    }
+    {        name: 'Abigail',        property1: 10,        property2: 5,        property3: 8    },
+    {        name: 'James',        property1: 10,        property2: 6,        property3: 8    },
+    {        name: 'John',        property1: 10,        property2: 6,        property3: 8    },
+    {        name: 'Anna',        property1: 10,        property2: 5,        property3: 8    },
+    {        name: 'Lucy',        property1: 10,        property2: 5,        property3: 8    }
 
 ];
 
@@ -133,3 +108,49 @@ export const TIMELINE = [
     ]
 
 ];
+
+export const CodeQuality = {
+    header1: [
+        {
+            text: 'Member',
+            align: 'center',
+            sortable: false,
+            value: 'name',
+        },
+        {
+            text: 'Code Quality',
+            value: 'codeQuality'
+        }
+    ],
+    data1: [
+        { name: 'Abigail',     codeQuality: 90},
+        { name: 'James',       codeQuality: 70},
+        { name: 'John',        codeQuality: 80},
+        { name: 'Anna',        codeQuality: 60},
+        { name: 'Lucy',        codeQuality: 90}
+    ],
+    header2: [
+        {
+            text: 'File Name',
+            align: 'center',
+            sortable: false,
+            value: 'name'
+        },
+        {
+            text: 'Code Quality',
+            value: 'codeQuality'
+        }
+    ],
+    data2: [
+        { name: 'SyntaxAwareDocument.java',        codeQuality: 90},
+        { name: 'IOAgent.java',        codeQuality: 80},
+        { name: 'PathDB.java',        codeQuality: 70},
+        { name: 'KeywordDB.java',        codeQuality: 60},
+        { name: 'ToJson.java',        codeQuality: 80},
+        { name: 'FindDialog.java',        codeQuality: 70},
+        { name: 'FontFrame.java',        codeQuality: 60},
+        { name: 'IntroFrame.java',        codeQuality: 90},
+        { name: 'TextEditorUI.java',        codeQuality: 70},
+        { name: 'TextLineNumber.java',        codeQuality: 30},
+    ],
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -117,3 +117,19 @@ export const PIEDATA = [
     ]
 
 ];
+
+export const TIMELINE = [
+    [
+        ['Sprint', 'member 1', 'member 2', 'member 3', 'Total'],
+        ['sprint 1',  12,     14,      10,             36],
+        ['sprint 2',  17,     14,      12,             43],
+        ['sprint 3',  14,     17,      25,             56]
+    ],
+    [
+        ['Sprint', 'member 1', 'member 2', 'member 3', 'Total'],
+        ['sprint 1',  5,      6,        8,             19],
+        ['sprint 2',  7,      4,        6,             17],
+        ['sprint 3',  7,      7,        5,             19]
+    ]
+
+];

--- a/src/tabs/GithubCodeQuality.vue
+++ b/src/tabs/GithubCodeQuality.vue
@@ -1,7 +1,7 @@
 <template>
     <v-layout row wrap>
         <v-flex xs6>
-            <TableChart :data="data.data1" :headers="data.header1" title="Code Quality by Members"></TableChart>
+            <TableChart :data="data.data1" :headers="data.header1" title="By Members"></TableChart>
             <v-layout justify-center align-center>
                 <v-card blue-grey lighten-4 width="94%">
                     <p class="headline mb-0 text-xs-center" style="background-color: gainsboro">Project Code Quality: 82</p>
@@ -9,7 +9,7 @@
             </v-layout>
         </v-flex>
         <v-flex xs6>
-            <TableChart :data="data.data2" :headers="data.header2" title="Code Quality by Files"></TableChart>
+            <TableChart :data="data.data2" :headers="data.header2" title="By Files"></TableChart>
         </v-flex>
 
     </v-layout>

--- a/src/tabs/GithubCodeQuality.vue
+++ b/src/tabs/GithubCodeQuality.vue
@@ -1,0 +1,29 @@
+<template>
+    <v-layout row wrap>
+        <v-flex xs6>
+            <TableChart :data="data.data1" :headers="data.header1" title="Code Quality by Members"></TableChart>
+            <v-layout justify-center align-center>
+                <v-card blue-grey lighten-4 width="94%">
+                    <p class="headline mb-0 text-xs-center" style="background-color: gainsboro">Project Code Quality: 82</p>
+                </v-card>
+            </v-layout>
+        </v-flex>
+        <v-flex xs6>
+            <TableChart :data="data.data2" :headers="data.header2" title="Code Quality by Files"></TableChart>
+        </v-flex>
+
+    </v-layout>
+</template>
+
+<script>
+    import TableChart from "../components/TableChart";
+    export default {
+        name: "GithubCodeQuality",
+        components: {TableChart},
+        props: ["data"]
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/src/tabs/GithubTimeline.vue
+++ b/src/tabs/GithubTimeline.vue
@@ -1,0 +1,24 @@
+<template>
+    <v-card height="50%">
+        <v-container width="100%">
+            <v-container>
+                <v-layout justify-center>
+                    <ComboChart :data="data[0]" title="commit"></ComboChart>
+                    <ComboChart :data="data[1]" title="pull request"></ComboChart>
+                </v-layout>
+            </v-container>
+        </v-container>
+    </v-card>
+
+</template>
+
+<script>
+    import ComboChart from "../components/ComboChart"
+    export default {
+        name: "GithubTimeline",
+        components: {
+            ComboChart
+        },
+        props: ["data"]
+    }
+</script>

--- a/src/views/GitHub.vue
+++ b/src/views/GitHub.vue
@@ -16,11 +16,13 @@
     //import BarChart from "@/components/BarChart";
     import GithubContribution from "../tabs/GithubContribution";
     import GithubTimeline from "../tabs/GithubTimeline";
+    import GithubCodeQuality from "../tabs/GithubCodeQuality";
     import {HEADERS1} from "../constants";
     import {MEMBERS} from "../constants";
     import {COMPLEXITY} from "../constants";
     import {PIEDATA} from "../constants";
     import {TIMELINE} from "../constants";
+    import {CodeQuality} from "../constants";
 
 
     export default {
@@ -31,11 +33,12 @@
                 title: "Github Statistic",
                 tabs: {
                     'Commits': {data: MEMBERS, component: DataTable, headers: HEADERS1, title: 'Commits in Sprints'},
-                    'Code Complexity': {data: COMPLEXITY, component: CircleChart, title: 'Contributions', headers: null},
+                    'Code Quality': {data:CodeQuality,component: GithubCodeQuality},
                     //'Pull Requests': {data: GRADIENT, component: SparkLine, title: 'Burn Down Chart', headers: null}
                     //'Comments': {data: PROCESSES, component: BarChart, title: 'User Stories', headers: null}
                     'Contribution': {data: PIEDATA, component: GithubContribution},
-                    'Commits and Pull requests': {data: TIMELINE, component: GithubTimeline}
+                    'Commits and Pull requests': {data: TIMELINE, component: GithubTimeline},
+
                 }
             }
         }

--- a/src/views/GitHub.vue
+++ b/src/views/GitHub.vue
@@ -14,11 +14,13 @@
     import CircleChart from "@/components/CircleChart";
     //import SparkLine from "@/components/SparkLine";
     //import BarChart from "@/components/BarChart";
-    import GithubContribution from "../tabs/GithubContribution"
+    import GithubContribution from "../tabs/GithubContribution";
+    import GithubTimeline from "../tabs/GithubTimeline";
     import {HEADERS1} from "../constants";
     import {MEMBERS} from "../constants";
     import {COMPLEXITY} from "../constants";
     import {PIEDATA} from "../constants";
+    import {TIMELINE} from "../constants";
 
 
     export default {
@@ -32,7 +34,8 @@
                     'Code Complexity': {data: COMPLEXITY, component: CircleChart, title: 'Contributions', headers: null},
                     //'Pull Requests': {data: GRADIENT, component: SparkLine, title: 'Burn Down Chart', headers: null}
                     //'Comments': {data: PROCESSES, component: BarChart, title: 'User Stories', headers: null}
-                    'Contribution': {data: PIEDATA, component: GithubContribution, }
+                    'Contribution': {data: PIEDATA, component: GithubContribution},
+                    'Timeline': {data: TIMELINE, component: GithubTimeline}
                 }
             }
         }

--- a/src/views/GitHub.vue
+++ b/src/views/GitHub.vue
@@ -35,7 +35,7 @@
                     //'Pull Requests': {data: GRADIENT, component: SparkLine, title: 'Burn Down Chart', headers: null}
                     //'Comments': {data: PROCESSES, component: BarChart, title: 'User Stories', headers: null}
                     'Contribution': {data: PIEDATA, component: GithubContribution},
-                    'Timeline': {data: TIMELINE, component: GithubTimeline}
+                    'Commits and Pull requests': {data: TIMELINE, component: GithubTimeline}
                 }
             }
         }


### PR DESCRIPTION
based on the requirement from the GitHub backend team 
![image](https://user-images.githubusercontent.com/35699883/54467007-bd8a9b00-473f-11e9-8bd9-810ae9476f07.png)
add the corresponding combo chart in the "commits and request" tab on the Github analyze page.
![image](https://user-images.githubusercontent.com/35699883/54467074-0fcbbc00-4740-11e9-8950-c02365c85564.png)

